### PR TITLE
set cache life = 0 in all envs except production

### DIFF
--- a/care/facility/summarisation/district/patient_summary.py
+++ b/care/facility/summarisation/district/patient_summary.py
@@ -1,5 +1,6 @@
 from celery.decorators import periodic_task
 from celery.schedules import crontab
+from django.conf import settings
 from django.db.models import Q, Subquery
 from django.utils.decorators import method_decorator
 from django.utils.timezone import now
@@ -52,7 +53,9 @@ class DistrictPatientSummaryViewSet(ListModelMixin, GenericViewSet):
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = DistrictSummaryFilter
 
-    @method_decorator(cache_page(60 * 10))
+    cache_limit = settings.API_CACHE_DURATION_IN_SECONDS
+
+    @method_decorator(cache_page(cache_limit))
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 

--- a/care/facility/summarisation/facility_capacity.py
+++ b/care/facility/summarisation/facility_capacity.py
@@ -4,6 +4,7 @@ from django.db.models import Sum
 from django.utils.decorators import method_decorator
 from django.utils.timezone import localtime, now
 from django.views.decorators.cache import cache_page
+from django.conf import settings
 from django_filters import rest_framework as filters
 from rest_framework import serializers
 from rest_framework.mixins import ListModelMixin
@@ -53,7 +54,9 @@ class FacilityCapacitySummaryViewSet(
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = FacilitySummaryFilter
 
-    @method_decorator(cache_page(60 * 10))
+    cache_limit = settings.API_CACHE_DURATION_IN_SECONDS
+
+    @method_decorator(cache_page(cache_limit))
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 

--- a/care/facility/summarisation/patient_summary.py
+++ b/care/facility/summarisation/patient_summary.py
@@ -5,6 +5,7 @@ from django.db.models import Q, Subquery
 from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from django.views.decorators.cache import cache_page
+from django.conf import settings
 from django_filters import rest_framework as filters
 from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
@@ -34,7 +35,9 @@ class PatientSummaryViewSet(ListModelMixin, GenericViewSet):
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = FacilitySummaryFilter
 
-    @method_decorator(cache_page(60 * 10))
+    cache_limit = settings.API_CACHE_DURATION_IN_SECONDS
+
+    @method_decorator(cache_page(cache_limit))
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 

--- a/care/facility/summarisation/tests_summary.py
+++ b/care/facility/summarisation/tests_summary.py
@@ -1,6 +1,7 @@
 from celery.decorators import periodic_task
 from celery.schedules import crontab
 from django.core.exceptions import ObjectDoesNotExist
+from django.conf import settings
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
@@ -33,7 +34,9 @@ class TestsSummaryViewSet(ListModelMixin, GenericViewSet):
     #         return queryset.filter(facility__state=user.state)
     #     return queryset.filter(facility__users__id__exact=user.id)
 
-    @method_decorator(cache_page(60 *60* 10))
+    cache_limit = settings.API_CACHE_DURATION_IN_SECONDS
+
+    @method_decorator(cache_page(cache_limit))
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 

--- a/care/facility/summarisation/triage_summary.py
+++ b/care/facility/summarisation/triage_summary.py
@@ -1,5 +1,6 @@
 from celery.decorators import periodic_task
 from celery.schedules import crontab
+from django.conf import settings
 from django.db.models import Count, Sum
 from django.utils.decorators import method_decorator
 from django.utils.timezone import localtime, now
@@ -33,7 +34,9 @@ class TriageSummaryViewSet(ListModelMixin, GenericViewSet):
     #         return queryset.filter(facility__state=user.state)
     #     return queryset.filter(facility__users__id__exact=user.id)
 
-    @method_decorator(cache_page(60 * 60 * 1))
+    cache_limit = settings.API_CACHE_DURATION_IN_SECONDS
+
+    @method_decorator(cache_page(cache_limit))
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 

--- a/care/users/api/viewsets/lsg.py
+++ b/care/users/api/viewsets/lsg.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django_filters import rest_framework as filters
@@ -12,6 +13,8 @@ from care.users.models import District, LocalBody, State, Ward
 
 from care.utils.cache.mixin import ListCacheResponseMixin
 
+cache_limit = settings.API_CACHE_DURATION_IN_SECONDS
+
 
 class PaginataionOverrideClass(PageNumberPagination):
     page_size = 500
@@ -22,7 +25,8 @@ class StateViewSet(ListCacheResponseMixin, mixins.ListModelMixin, GenericViewSet
     queryset = State.objects.all().order_by("id")
     pagination_class = PaginataionOverrideClass
 
-    @method_decorator(cache_page(3600))
+
+    @method_decorator(cache_page(cache_limit))
     @action(detail=True, methods=["get"])
     def districts(self, *args, **kwargs):
         state = self.get_object()
@@ -43,14 +47,16 @@ class DistrictViewSet(ListCacheResponseMixin, mixins.ListModelMixin, GenericView
     filterset_class = DistrictFilterSet
     pagination_class = PaginataionOverrideClass
 
-    @method_decorator(cache_page(3600))
+
+    @method_decorator(cache_page(cache_limit))
     @action(detail=True, methods=["get"])
     def local_bodies(self, *args, **kwargs):
         district = self.get_object()
         serializer = LocalBodySerializer(district.localbody_set.all().order_by("name"), many=True)
         return Response(data=serializer.data)
 
-    @method_decorator(cache_page(3600))
+
+    @method_decorator(cache_page(cache_limit))
     @action(detail=True, methods=["get"])
     def get_all_local_body(self, *args, **kwargs):
         district = self.get_object()

--- a/care/utils/cache/mixin.py
+++ b/care/utils/cache/mixin.py
@@ -1,5 +1,8 @@
+from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
+
+cache_limit = settings.API_CACHE_DURATION_IN_SECONDS
 
 
 class BaseCacheResponseMixin:
@@ -7,13 +10,15 @@ class BaseCacheResponseMixin:
 
 
 class ListCacheResponseMixin(BaseCacheResponseMixin):
-    @method_decorator(cache_page(60 * 100))
+
+    @method_decorator(cache_page(cache_limit))
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 
 
 class RetrieveCacheResponseMixin(BaseCacheResponseMixin):
-    @method_decorator(cache_page(60 * 100))
+
+    @method_decorator(cache_page(cache_limit))
     def retrieve(self, request, *args, **kwargs):
         return super().retrieve(request, *args, **kwargs)
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -273,7 +273,7 @@ LOGGING = {
     "formatters": {
         "verbose": {"format": "%(levelname)s %(asctime)s %(module)s " "%(process)d %(thread)d %(message)s"}
     },
-    "handlers": {"console": {"level": "DEBUG", "class": "logging.StreamHandler", "formatter": "verbose",}},
+    "handlers": {"console": {"level": "DEBUG", "class": "logging.StreamHandler", "formatter": "verbose", }},
     "root": {"level": "INFO", "handlers": ["console"]},
 }
 
@@ -450,3 +450,4 @@ AUDIT_LOG = {
 }
 
 SEND_SMS_NOTIFICATION = False
+API_CACHE_DURATION_IN_SECONDS = 0

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -158,6 +158,7 @@ sentry_sdk.init(
 # ------------------------------------------------------------------------------
 
 IS_PRODUCTION = True
+API_CACHE_DURATION_IN_SECONDS=60 * 10
 
 # SMS API KEYS
 USE_SMS = True


### PR DESCRIPTION
Cache lifetime is set as 0 for all envs except Production. 
Production cache lifetime would 60 * 10 seconds.
Cache variable is set in the settings file.